### PR TITLE
feat: Prisma クライアントのセットアップと Supabase DB の導入

### DIFF
--- a/.vscode/TailwindCSS.code-snippets
+++ b/.vscode/TailwindCSS.code-snippets
@@ -2,8 +2,7 @@
   "大枠のVStack": {
     "prefix": "frame_Vstack",
     "body": [
-      "{/* 大枠のVStack */}",
-      "<div className=\"flex flex-col items-center space-y-4 w-screen h-screen\">",
+      "<div className=\"flex flex-col items-center min-h-screen relative\">",
       "  $0",
       "</div>"
     ],
@@ -18,12 +17,26 @@
     ],
     "description": "縦並び。justify(主軸)-で上下の揃えを、items(交差軸)-で左右の揃えをします"
   },
+    "クラス内VStack": {
+    "prefix": "vstack_class",
+    "body": [
+      "flex flex-col items-center w-full"
+    ],
+    "description": "縦並び。justify(主軸)-で上下の揃えを、items(交差軸)-で左右の揃えをします"
+  },
   "通常のHStack": {
     "prefix": "hstack",
     "body": [
       "<div className=\"flex flex-row items-center justify-center w-full\">",
       "  $0",
       "</div>"
+    ],
+    "description": "横並び。justify(主軸)-で左右の揃えを、items(交差軸)-で上下の揃えをします"
+  },
+    "クラス内HStack": {
+    "prefix": "hstack_class",
+    "body": [
+      "flex flex-row items-center justify-center w-full"
     ],
     "description": "横並び。justify(主軸)-で左右の揃えを、items(交差軸)-で上下の揃えをします"
   },
@@ -49,5 +62,12 @@
       "<div className=\"flex-grow\"></div>"
     ],
     "description": "Tailwindの擬似的spacer"
+  },
+  "Tailwind FullCover absolute inset-0": {
+    "prefix": "background",
+    "body": [
+      "<div className=\"absolute inset-0 z-0$1\">$2</div>"
+    ],
+    "description": "Tailwind: full cover absolute inset-0 z-0 block"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,179 +1,572 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+  schemas   = ["auth", "public"]
 }
 
-model active_storage_attachments {
-  id                   BigInt               @id @default(autoincrement())
-  name                 String               @db.VarChar
-  record_type          String               @db.VarChar
-  record_id            BigInt
-  blob_id              BigInt
-  created_at           DateTime             @db.Timestamp(6)
-  active_storage_blobs active_storage_blobs @relation(fields: [blob_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_c3b3935057")
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model audit_log_entries {
+  instance_id String?   @db.Uuid
+  id          String    @id @db.Uuid
+  payload     Json?     @db.Json
+  created_at  DateTime? @db.Timestamptz(6)
+  ip_address  String    @default("") @db.VarChar(64)
 
-  @@unique([record_type, record_id, name, blob_id], map: "index_active_storage_attachments_uniqueness")
-  @@index([blob_id], map: "index_active_storage_attachments_on_blob_id")
+  @@index([instance_id], map: "audit_logs_instance_id_idx")
+  @@schema("auth")
 }
 
-model active_storage_blobs {
-  id                             BigInt                           @id @default(autoincrement())
-  key                            String                           @unique(map: "index_active_storage_blobs_on_key") @db.VarChar
-  filename                       String                           @db.VarChar
-  content_type                   String?                          @db.VarChar
-  metadata                       String?
-  service_name                   String                           @db.VarChar
-  byte_size                      BigInt
-  checksum                       String?                          @db.VarChar
-  created_at                     DateTime                         @db.Timestamp(6)
-  active_storage_attachments     active_storage_attachments[]
-  active_storage_variant_records active_storage_variant_records[]
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model flow_state {
+  id                     String                @id @db.Uuid
+  user_id                String?               @db.Uuid
+  auth_code              String
+  code_challenge_method  code_challenge_method
+  code_challenge         String
+  provider_type          String
+  provider_access_token  String?
+  provider_refresh_token String?
+  created_at             DateTime?             @db.Timestamptz(6)
+  updated_at             DateTime?             @db.Timestamptz(6)
+  authentication_method  String
+  auth_code_issued_at    DateTime?             @db.Timestamptz(6)
+  saml_relay_states      saml_relay_states[]
+
+  @@index([created_at(sort: Desc)])
+  @@index([auth_code], map: "idx_auth_code")
+  @@index([user_id, authentication_method], map: "idx_user_id_auth_method")
+  @@schema("auth")
 }
 
-model active_storage_variant_records {
-  id                   BigInt               @id @default(autoincrement())
-  blob_id              BigInt
-  variation_digest     String               @db.VarChar
-  active_storage_blobs active_storage_blobs @relation(fields: [blob_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_993965df05")
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model identities {
+  provider_id     String
+  user_id         String    @db.Uuid
+  identity_data   Json
+  provider        String
+  last_sign_in_at DateTime? @db.Timestamptz(6)
+  created_at      DateTime? @db.Timestamptz(6)
+  updated_at      DateTime? @db.Timestamptz(6)
+  email           String?   @default(dbgenerated("lower((identity_data ->> 'email'::text))"))
+  id              String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  users           users     @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
-  @@unique([blob_id, variation_digest], map: "index_active_storage_variant_records_uniqueness")
+  @@unique([provider_id, provider], map: "identities_provider_id_provider_unique")
+  @@index([email])
+  @@index([user_id])
+  @@schema("auth")
 }
 
-model ar_internal_metadata {
-  key        String   @id @db.VarChar
-  value      String?  @db.VarChar
-  created_at DateTime @db.Timestamp(6)
-  updated_at DateTime @db.Timestamp(6)
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model instances {
+  id              String    @id @db.Uuid
+  uuid            String?   @db.Uuid
+  raw_base_config String?
+  created_at      DateTime? @db.Timestamptz(6)
+  updated_at      DateTime? @db.Timestamptz(6)
+
+  @@schema("auth")
 }
 
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model mfa_amr_claims {
+  session_id            String   @db.Uuid
+  created_at            DateTime @db.Timestamptz(6)
+  updated_at            DateTime @db.Timestamptz(6)
+  authentication_method String
+  id                    String   @id(map: "amr_id_pk") @db.Uuid
+  sessions              sessions @relation(fields: [session_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([session_id, authentication_method], map: "mfa_amr_claims_session_id_authentication_method_pkey")
+  @@schema("auth")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model mfa_challenges {
+  id                     String      @id @db.Uuid
+  factor_id              String      @db.Uuid
+  created_at             DateTime    @db.Timestamptz(6)
+  verified_at            DateTime?   @db.Timestamptz(6)
+  ip_address             String      @db.Inet
+  otp_code               String?
+  web_authn_session_data Json?
+  mfa_factors            mfa_factors @relation(fields: [factor_id], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "mfa_challenges_auth_factor_id_fkey")
+
+  @@index([created_at(sort: Desc)], map: "mfa_challenge_created_at_idx")
+  @@schema("auth")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model mfa_factors {
+  id                   String           @id @db.Uuid
+  user_id              String           @db.Uuid
+  friendly_name        String?
+  factor_type          factor_type
+  status               factor_status
+  created_at           DateTime         @db.Timestamptz(6)
+  updated_at           DateTime         @db.Timestamptz(6)
+  secret               String?
+  phone                String?
+  last_challenged_at   DateTime?        @unique @db.Timestamptz(6)
+  web_authn_credential Json?
+  web_authn_aaguid     String?          @db.Uuid
+  mfa_challenges       mfa_challenges[]
+  users                users            @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([user_id, phone], map: "unique_phone_factor_per_user")
+  @@index([user_id, created_at], map: "factor_id_created_at_idx")
+  @@index([user_id])
+  @@schema("auth")
+}
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model one_time_tokens {
+  id         String              @id @db.Uuid
+  user_id    String              @db.Uuid
+  token_type one_time_token_type
+  token_hash String
+  relates_to String
+  created_at DateTime            @default(now()) @db.Timestamp(6)
+  updated_at DateTime            @default(now()) @db.Timestamp(6)
+  users      users               @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([user_id, token_type])
+  @@index([relates_to], map: "one_time_tokens_relates_to_hash_idx", type: Hash)
+  @@index([token_hash], map: "one_time_tokens_token_hash_hash_idx", type: Hash)
+  @@schema("auth")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model refresh_tokens {
+  instance_id String?   @db.Uuid
+  id          BigInt    @id @default(autoincrement())
+  token       String?   @unique(map: "refresh_tokens_token_unique") @db.VarChar(255)
+  user_id     String?   @db.VarChar(255)
+  revoked     Boolean?
+  created_at  DateTime? @db.Timestamptz(6)
+  updated_at  DateTime? @db.Timestamptz(6)
+  parent      String?   @db.VarChar(255)
+  session_id  String?   @db.Uuid
+  sessions    sessions? @relation(fields: [session_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([instance_id])
+  @@index([instance_id, user_id])
+  @@index([parent])
+  @@index([session_id, revoked])
+  @@index([updated_at(sort: Desc)])
+  @@schema("auth")
+}
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model saml_providers {
+  id                String        @id @db.Uuid
+  sso_provider_id   String        @db.Uuid
+  entity_id         String        @unique
+  metadata_xml      String
+  metadata_url      String?
+  attribute_mapping Json?
+  created_at        DateTime?     @db.Timestamptz(6)
+  updated_at        DateTime?     @db.Timestamptz(6)
+  name_id_format    String?
+  sso_providers     sso_providers @relation(fields: [sso_provider_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([sso_provider_id])
+  @@schema("auth")
+}
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model saml_relay_states {
+  id              String        @id @db.Uuid
+  sso_provider_id String        @db.Uuid
+  request_id      String
+  for_email       String?
+  redirect_to     String?
+  created_at      DateTime?     @db.Timestamptz(6)
+  updated_at      DateTime?     @db.Timestamptz(6)
+  flow_state_id   String?       @db.Uuid
+  flow_state      flow_state?   @relation(fields: [flow_state_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  sso_providers   sso_providers @relation(fields: [sso_provider_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([created_at(sort: Desc)])
+  @@index([for_email])
+  @@index([sso_provider_id])
+  @@schema("auth")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model schema_migrations {
+  version String @id @db.VarChar(255)
+
+  @@schema("auth")
+}
+
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model sessions {
+  id             String           @id @db.Uuid
+  user_id        String           @db.Uuid
+  created_at     DateTime?        @db.Timestamptz(6)
+  updated_at     DateTime?        @db.Timestamptz(6)
+  factor_id      String?          @db.Uuid
+  aal            aal_level?
+  not_after      DateTime?        @db.Timestamptz(6)
+  refreshed_at   DateTime?        @db.Timestamp(6)
+  user_agent     String?
+  ip             String?          @db.Inet
+  tag            String?
+  mfa_amr_claims mfa_amr_claims[]
+  refresh_tokens refresh_tokens[]
+  users          users            @relation(fields: [user_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([not_after(sort: Desc)])
+  @@index([user_id])
+  @@index([user_id, created_at], map: "user_id_created_at_idx")
+  @@schema("auth")
+}
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+/// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
+model sso_domains {
+  id              String        @id @db.Uuid
+  sso_provider_id String        @db.Uuid
+  domain          String
+  created_at      DateTime?     @db.Timestamptz(6)
+  updated_at      DateTime?     @db.Timestamptz(6)
+  sso_providers   sso_providers @relation(fields: [sso_provider_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([sso_provider_id])
+  @@schema("auth")
+}
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+/// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
+model sso_providers {
+  id                String              @id @db.Uuid
+  resource_id       String?
+  created_at        DateTime?           @db.Timestamptz(6)
+  updated_at        DateTime?           @db.Timestamptz(6)
+  saml_providers    saml_providers[]
+  saml_relay_states saml_relay_states[]
+  sso_domains       sso_domains[]
+
+  @@schema("auth")
+}
+
+/// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/check-constraints for more info.
+/// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+/// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
+model users {
+  instance_id                 String?           @db.Uuid
+  id                          String            @id @db.Uuid
+  aud                         String?           @db.VarChar(255)
+  role                        String?           @db.VarChar(255)
+  email                       String?           @db.VarChar(255)
+  encrypted_password          String?           @db.VarChar(255)
+  email_confirmed_at          DateTime?         @db.Timestamptz(6)
+  invited_at                  DateTime?         @db.Timestamptz(6)
+  confirmation_token          String?           @db.VarChar(255)
+  confirmation_sent_at        DateTime?         @db.Timestamptz(6)
+  recovery_token              String?           @db.VarChar(255)
+  recovery_sent_at            DateTime?         @db.Timestamptz(6)
+  email_change_token_new      String?           @db.VarChar(255)
+  email_change                String?           @db.VarChar(255)
+  email_change_sent_at        DateTime?         @db.Timestamptz(6)
+  last_sign_in_at             DateTime?         @db.Timestamptz(6)
+  raw_app_meta_data           Json?
+  raw_user_meta_data          Json?
+  is_super_admin              Boolean?
+  created_at                  DateTime?         @db.Timestamptz(6)
+  updated_at                  DateTime?         @db.Timestamptz(6)
+  phone                       String?           @unique
+  phone_confirmed_at          DateTime?         @db.Timestamptz(6)
+  phone_change                String?           @default("")
+  phone_change_token          String?           @default("") @db.VarChar(255)
+  phone_change_sent_at        DateTime?         @db.Timestamptz(6)
+  confirmed_at                DateTime?         @default(dbgenerated("LEAST(email_confirmed_at, phone_confirmed_at)")) @db.Timestamptz(6)
+  email_change_token_current  String?           @default("") @db.VarChar(255)
+  email_change_confirm_status Int?              @default(0) @db.SmallInt
+  banned_until                DateTime?         @db.Timestamptz(6)
+  reauthentication_token      String?           @default("") @db.VarChar(255)
+  reauthentication_sent_at    DateTime?         @db.Timestamptz(6)
+  is_sso_user                 Boolean           @default(false)
+  deleted_at                  DateTime?         @db.Timestamptz(6)
+  is_anonymous                Boolean           @default(false)
+  identities                  identities[]
+  mfa_factors                 mfa_factors[]
+  one_time_tokens             one_time_tokens[]
+  sessions                    sessions[]
+  Company_users               Company_users[]
+  admin_users                 admin_users[]
+  bookmarks                   bookmarks[]
+  likes                       likes[]
+  posts                       posts[]
+  profiles                    profiles[]
+
+  @@index([instance_id])
+  @@index([is_anonymous])
+  @@schema("auth")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model Companies {
+  id                BigInt              @id @default(autoincrement())
+  name              String
+  created_at        DateTime            @default(now()) @db.Timestamptz(6)
+  updated_at        DateTime            @default(now()) @db.Timestamptz(6)
+  deleted_at        DateTime?           @db.Timestamptz(6)
+  Company_users     Company_users[]
+  company_bookmarks company_bookmarks[]
+  invite_codes      invite_codes[]
+
+  @@schema("public")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model Company_users {
+  id         BigInt    @id @default(autoincrement())
+  company_id BigInt
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime  @default(now()) @db.Timestamptz(6)
+  deleted_at DateTime? @db.Timestamptz(6)
+  role       String
+  user_id    String?   @default(dbgenerated("auth.uid()")) @db.Uuid
+  Companies  Companies @relation(fields: [company_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  users      users?    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@schema("public")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model admin_users {
+  id         BigInt    @id @default(autoincrement())
+  user_id    String    @default(dbgenerated("auth.uid()")) @db.Uuid
+  role       String
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime  @default(now()) @db.Timestamptz(6)
+  deleted_at DateTime? @db.Timestamptz(6)
+  users      users     @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@schema("public")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model bookmarks {
-  id         BigInt   @id @default(autoincrement())
-  user_id    BigInt
+  id         BigInt    @id @default(autoincrement())
   post_id    BigInt
-  created_at DateTime @db.Timestamp(6)
-  updated_at DateTime @db.Timestamp(6)
-  users      users    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_c1ff6fa4ac")
-  posts      posts    @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_d8b54790ff")
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime  @default(now()) @db.Timestamptz(6)
+  deleted_at DateTime? @db.Timestamptz(6)
+  user_id    String?   @default(dbgenerated("auth.uid()")) @db.Uuid
+  posts      posts     @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  users      users?    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@unique([user_id, post_id], map: "index_bookmarks_on_user_id_and_post_id")
-  @@index([post_id], map: "index_bookmarks_on_post_id")
-  @@index([user_id], map: "index_bookmarks_on_user_id")
+  @@schema("public")
 }
 
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model company_bookmarks {
+  id         BigInt    @id @default(autoincrement())
+  post_id    BigInt
+  company_id BigInt
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime  @default(now()) @db.Timestamptz(6)
+  deleted_at DateTime? @db.Timestamptz(6)
+  Companies  Companies @relation(fields: [company_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  posts      posts     @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@schema("public")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model default_tag_relations {
   id             BigInt       @id @default(autoincrement())
   post_id        BigInt
   default_tag_id BigInt
-  created_at     DateTime     @db.Timestamp(6)
-  updated_at     DateTime     @db.Timestamp(6)
-  default_tags   default_tags @relation(fields: [default_tag_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_6378bcb8c4")
-  posts          posts        @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_6480885485")
+  created_at     DateTime     @default(now()) @db.Timestamptz(6)
+  updated_at     DateTime     @default(now()) @db.Timestamptz(6)
+  deleted_at     DateTime?    @db.Timestamptz(6)
+  default_tags   default_tags @relation(fields: [default_tag_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  posts          posts        @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@index([default_tag_id], map: "index_default_tag_relations_on_default_tag_id")
-  @@index([post_id], map: "index_default_tag_relations_on_post_id")
+  @@schema("public")
 }
 
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model default_tags {
   id                    BigInt                  @id @default(autoincrement())
-  name                  String?                 @db.VarChar
-  created_at            DateTime                @db.Timestamp(6)
-  updated_at            DateTime                @db.Timestamp(6)
+  name                  String
+  created_at            DateTime                @default(now()) @db.Timestamptz(6)
+  updated_at            DateTime                @default(now()) @db.Timestamptz(6)
+  deleted_at            DateTime?               @db.Timestamptz(6)
   default_tag_relations default_tag_relations[]
+
+  @@schema("public")
 }
 
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
+model invite_codes {
+  id         BigInt    @id @default(autoincrement())
+  code       String
+  role       String
+  max_uses   Int
+  used_count Int?
+  expires_at DateTime? @db.Timestamptz(6)
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime  @default(now()) @db.Timestamp(6)
+  deleted_at DateTime? @db.Timestamptz(6)
+  company_id BigInt
+  Companies  Companies @relation(fields: [company_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@schema("public")
+}
+
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model likes {
-  id         BigInt   @id @default(autoincrement())
-  user_id    BigInt
+  id         BigInt    @id @default(autoincrement())
   post_id    BigInt
-  created_at DateTime @db.Timestamp(6)
-  updated_at DateTime @db.Timestamp(6)
-  users      users    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_1e09b5dabf")
-  posts      posts    @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_87a8aac469")
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  deleted_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime? @db.Timestamptz(6)
+  user_id    String?   @default(dbgenerated("auth.uid()")) @db.Uuid
+  posts      posts     @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  users      users?    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@unique([user_id, post_id], map: "index_likes_on_user_id_and_post_id")
-  @@index([post_id], map: "index_likes_on_post_id")
-  @@index([user_id], map: "index_likes_on_user_id")
+  @@schema("public")
 }
 
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model limited_tag_relations {
   id             BigInt       @id @default(autoincrement())
   post_id        BigInt
   limited_tag_id BigInt
-  created_at     DateTime     @db.Timestamp(6)
-  updated_at     DateTime     @db.Timestamp(6)
-  limited_tags   limited_tags @relation(fields: [limited_tag_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_4abeb2e268")
-  posts          posts        @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_6b7f90ca60")
+  created_at     DateTime     @default(now()) @db.Timestamptz(6)
+  updated_at     DateTime     @default(now()) @db.Timestamptz(6)
+  deleted_at     DateTime?    @db.Timestamptz(6)
+  limited_tags   limited_tags @relation(fields: [limited_tag_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  posts          posts        @relation(fields: [post_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@index([limited_tag_id], map: "index_limited_tag_relations_on_limited_tag_id")
-  @@index([post_id], map: "index_limited_tag_relations_on_post_id")
+  @@schema("public")
 }
 
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model limited_tags {
   id                    BigInt                  @id @default(autoincrement())
-  name                  String?                 @db.VarChar
-  start_at              DateTime?               @db.Timestamp(6)
-  end_at                DateTime?               @db.Timestamp(6)
-  description           String?
-  created_at            DateTime                @db.Timestamp(6)
-  updated_at            DateTime                @db.Timestamp(6)
+  name                  String
+  start_at              DateTime                @db.Timestamptz(6)
+  expired_at            DateTime?               @db.Timestamptz(6)
+  created_at            DateTime                @default(now()) @db.Timestamptz(6)
+  updated_at            DateTime?               @default(now()) @db.Timestamptz(6)
+  deleted_at            DateTime?               @db.Timestamptz(6)
   limited_tag_relations limited_tag_relations[]
+
+  @@schema("public")
 }
 
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model posts {
-  id                    BigInt                  @id @default(autoincrement())
-  user_id               BigInt
-  content               String?
-  created_at            DateTime                @db.Timestamp(6)
-  updated_at            DateTime                @db.Timestamp(6)
+  id                    BigInt                  @id @unique @default(autoincrement())
+  user_id               String                  @default(dbgenerated("auth.uid()")) @db.Uuid
+  content               String
+  likes_count           BigInt?
+  bookmarks_count       BigInt?
+  created_at            DateTime                @default(now()) @db.Timestamptz(6)
+  updated_at            DateTime                @default(now()) @db.Timestamptz(6)
+  deleted_at            DateTime?               @db.Timestamptz(6)
   bookmarks             bookmarks[]
+  company_bookmarks     company_bookmarks[]
   default_tag_relations default_tag_relations[]
   likes                 likes[]
   limited_tag_relations limited_tag_relations[]
-  users                 users                   @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_5b5ddfd518")
+  users                 users                   @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@index([user_id], map: "index_posts_on_user_id")
+  @@schema("public")
 }
 
+/// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model profiles {
   id              BigInt    @id @default(autoincrement())
-  user_id         BigInt
-  phone_number    String?   @db.VarChar
-  birth_date      DateTime? @db.Date
-  user_name       String?   @db.VarChar
-  graduation_year Int?
-  gender          String?   @db.VarChar
-  affiliation     String?   @db.VarChar
-  real_name       String?   @db.VarChar
-  real_name_kana  String?   @db.VarChar
-  user_sei        String?   @db.VarChar
-  user_mei        String?   @db.VarChar
-  user_sei_kana   String?   @db.VarChar
-  user_mei_kana   String?   @db.VarChar
-  completed       Boolean?
-  created_at      DateTime  @db.Timestamp(6)
-  updated_at      DateTime  @db.Timestamp(6)
-  users           users     @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "fk_rails_e424190865")
+  created_at      DateTime  @default(now()) @db.Timestamptz(6)
+  user_id         String?   @db.Uuid
+  user_identifier String?   @unique
+  birth_date      DateTime? @db.Time(6)
+  user_name       String?
+  graduation_year String?
+  gender          String?
+  affiliation     String?
+  sei             String?
+  mei             String?
+  sei_kana        String?
+  mei_kana        String?
+  completed       Boolean
+  updated_at      DateTime  @db.Timestamptz(6)
+  deleted_at      DateTime? @db.Timestamptz(6)
+  users           users?    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
-  @@index([user_id], map: "index_profiles_on_user_id")
+  @@schema("public")
 }
 
-model schema_migrations {
-  version String @id @db.VarChar
+enum aal_level {
+  aal1
+  aal2
+  aal3
+
+  @@schema("auth")
 }
 
-model users {
-  id              BigInt      @id @default(autoincrement())
-  user_identifier String?     @db.VarChar
-  email           String?     @db.VarChar
-  password        String?     @db.VarChar
-  created_at      DateTime    @db.Timestamp(6)
-  updated_at      DateTime    @db.Timestamp(6)
-  bookmarks       bookmarks[]
-  likes           likes[]
-  posts           posts[]
-  profiles        profiles[]
+enum code_challenge_method {
+  s256
+  plain
+
+  @@schema("auth")
+}
+
+enum factor_status {
+  unverified
+  verified
+
+  @@schema("auth")
+}
+
+enum factor_type {
+  totp
+  webauthn
+  phone
+
+  @@schema("auth")
+}
+
+enum one_time_token_type {
+  confirmation_token
+  reauthentication_token
+  recovery_token
+  email_change_token_new
+  email_change_token_current
+  phone_change_token
+
+  @@schema("auth")
 }

--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -1,0 +1,112 @@
+
+export default function () {
+
+
+
+  return (
+    <>
+      {/* 大枠のVStack */}
+      <div className="flex flex-col items-center min-h-screen relative">
+        {/* 背景 */}
+        <div className="absolute inset-0 z-0 items-center">
+          {/* 動画再生部分 */}
+          <div className="bg-amber-300 w-full h-11/12 relative">
+            <div className="flex flex-col items-center absolute bottom-0">
+              <p className="text-center text-base font-normal text-gray-800">
+                小悪魔コンカフェ
+              </p>
+              <p className="text-center text-base font-normal text-gray-800">
+                初めまして＠愛すです
+              </p>
+            </div>
+          </div>
+          {/* 下タブバー */}
+          <div className="bg-gray-300 w-full h-1/12 flex flex-row justify-between">
+            {/* レコメンド */}
+            <button className="flex flex-col items-center ">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+              </svg>
+              <p className="text-center text-xs font-normal text-gray-800">
+                レコメンド
+              </p>
+            </button>
+            {/* 友達 */}
+            <button className="flex flex-col items-center">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+              </svg>
+              <p className="text-center text-xs font-normal text-gray-800">
+                友達
+              </p>
+            </button>
+
+            {/* 投稿＋ */}
+            <button className="flex flex-col items-center">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+              </svg>
+              <p className="text-center text-xs font-normal text-gray-800">
+                投稿
+              </p>
+            </button>
+
+            {/* メッセージ */}
+            <button className="flex flex-col items-center">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.76c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.076-4.076a1.526 1.526 0 0 1 1.037-.443 48.282 48.282 0 0 0 5.68-.494c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+              </svg>
+
+              <p className="text-center text-xs font-normal text-gray-800">
+                メッセージ
+              </p>
+            </button>
+
+            {/* プロフィール */}
+            <button className="flex flex-col items-center">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+              </svg>
+              <p className="text-center text-xs font-normal text-gray-800">
+                プロフィール
+              </p>
+            </button>
+          </div>
+
+
+        </div>
+
+        {/* 上のボタン */}
+        <div className="flex flex-row items-center justify-between w-full z-10 mt-8 px-4">
+
+          <button className="">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+            </svg>
+          </button>
+
+          <div className="flex flex-row items-center justify-center space-x-4">
+            <p className="text-center text-base font-normal text-gray-800">
+              探索
+            </p>
+            <p className="text-center text-base font-normal text-gray-800">
+              フォロー中
+            </p>
+            <p className="text-center text-base font-normal text-gray-800">
+              おすすめ
+            </p>
+          </div>
+
+          <button className="">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+            </svg>
+          </button>
+
+        </div>
+
+
+      </div>
+    </>
+  );
+}

--- a/src/app/learn/test/page.tsx
+++ b/src/app/learn/test/page.tsx
@@ -1,0 +1,59 @@
+
+export default function () {
+
+
+
+  return (
+    <>
+      <div className="relative min-h-screen bg-black text-white">
+        {/* 背景の波 */}
+        <div className="absolute inset-0 z-0">
+          <svg
+            className="w-full h-[300px]"
+            viewBox="0 0 1440 320"
+            preserveAspectRatio="none"
+          >
+            <path
+              fill="#f472b6"
+              d="M0,160 C480,0 960,320 1440,160 L1440,0 L0,0 Z"
+            />
+          </svg>
+        </div>
+
+        {/* メインコンテンツ */}
+        <div className="relative z-10 pt-32 flex flex-col items-center">
+          {/* アバター */}
+          <div className="w-24 h-24 rounded-full border-4 border-white overflow-hidden">
+            <img
+              src="/avatar.jpg" // ここに画像パスを指定
+              alt="Avatar"
+              className="w-full h-full object-cover"
+            />
+          </div>
+
+          <h1 className="mt-4 text-lg font-semibold">Julliet Yirrah</h1>
+          <p className="text-sm text-gray-300">View full profile</p>
+
+          {/* ボタンリスト */}
+          <div className="mt-6 w-full max-w-sm space-y-4 px-4">
+            <button className="w-full py-3 bg-pink-100/10 rounded-md text-left px-4">
+              Account Information
+            </button>
+            <button className="w-full py-3 bg-pink-100/10 rounded-md text-left px-4">
+              Password
+            </button>
+            <button className="w-full py-3 bg-pink-100/10 rounded-md text-left px-4">
+              Settings
+            </button>
+            <button className="w-full py-3 bg-pink-100/10 rounded-md text-left px-4">
+              Help & Support
+            </button>
+            <button className="w-full py-3 bg-pink-600 text-white rounded-md text-left px-4">
+              Log out
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## 概要
Supabase の PostgreSQL に接続し、Prisma を使って DB スキーマを introspect して Prisma Client を生成しました。

## 実施内容
- `.env` に Supabase の接続情報（DATABASE_URL, DIRECT_URL）を追加
- `prisma/schema.prisma` を設定し、`pnpm dlx prisma db pull` でスキーマを取得
- `pnpm dlx prisma generate` により Prisma Client を生成

## 補足
- Supabase の auth スキーマに依存しているため、`multiSchema` の preview feature を有効化
- Prisma v6.11.1 を使用

## 今後の予定
- Prisma Client を用いた API 実装
- Supabase Auth と連携したユーザー処理の実装